### PR TITLE
[Update] add compress xz

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,12 @@ interpreter (and only the Python3 package installs scripts)::
 News
 ----
 
+ * 2023-10-07: **Version 0.11.4**.
+
+  * Improvements:
+
+    * add compress xz parameter
+
  * 2023-09-08: **Version 0.11.2**.
 
   * Bugfixes:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name='stdeb',
     # Keep version in sync with stdeb/__init__.py and install section
     # of README.rst.
-    version='0.11.3',
+    version='0.11.4',
     author='DdangJin',
     author_email='hdj997@gmail.com',
     description='Python to Debian source package conversion utility',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 import codecs
 
 with codecs.open('README.rst', encoding='utf-8') as file:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name='stdeb',
     # Keep version in sync with stdeb/__init__.py and install section
     # of README.rst.
-    version='0.11.2',
+    version='0.11.3',
     author='DdangJin',
     author_email='hdj997@gmail.com',
     description='Python to Debian source package conversion utility',

--- a/stdeb/__init__.py
+++ b/stdeb/__init__.py
@@ -1,5 +1,5 @@
 import logging
-__version__ = '0.11.3'  # keep in sync with ../setup.py
+__version__ = '0.11.4'  # keep in sync with ../setup.py
 
 log = logging.getLogger('stdeb')
 log.setLevel(logging.INFO)

--- a/stdeb/__init__.py
+++ b/stdeb/__init__.py
@@ -1,5 +1,5 @@
 import logging
-__version__ = '0.11.2'  # keep in sync with ../setup.py
+__version__ = '0.11.3'  # keep in sync with ../setup.py
 
 log = logging.getLogger('stdeb')
 log.setLevel(logging.INFO)

--- a/stdeb/command/bdist_deb.py
+++ b/stdeb/command/bdist_deb.py
@@ -17,19 +17,24 @@ class bdist_deb(Command):
         ('ignore-source-changes', None,
          'Ignore all changes on source when building source package '
          '(add -i.* option to dpkg-source'),
+        ('compress-xz', None,
+         'Use xzip (add -Zxz option to dpkg-buildpackage)'),
         ]
     boolean_options = [
         'sign-results',
         'ignore-source-changes',
+        'compress-xz',
         ]
 
     def initialize_options(self):
         self.sign_results = False
         self.ignore_source_changes = False
+        self.compress_xz = False
 
     def finalize_options(self):
         self.sign_results = bool(self.sign_results)
         self.ignore_source_changes = bool(self.ignore_source_changes)
+        self.compress_xz = bool(self.compress_xz)
 
     def run(self):
         # generate .dsc source pkg
@@ -83,6 +88,9 @@ class bdist_deb(Command):
 
         if self.ignore_source_changes:
             syscmd.append('-i.*')
+
+        if self.compress_xz:
+            syscmd.append('-Zxz')
 
         print('CALLING ' + ' '.join(syscmd))
         util.process_command(syscmd, cwd=target_dir)

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -36,6 +36,7 @@ class common_debian_package_command(Command):
         self.with_dh_systemd = False
         self.sign_results = False
         self.ignore_source_changes = False
+        self.compress_xz = False
         self.compat = DH_DEFAULT_VERS
 
         # deprecated options

--- a/stdeb/command/sdist_dsc.py
+++ b/stdeb/command/sdist_dsc.py
@@ -142,6 +142,7 @@ class sdist_dsc(common_debian_package_command):
                   remove_expanded_source_dir=self.remove_expanded_source_dir,
                   sign_dsc=self.sign_results,
                   ignore_source_changes=self.ignore_source_changes,
+                  compress_xz=self.compress_xz,
                   )
 
         for rmdir in cleanup_dirs:

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -135,6 +135,8 @@ stdeb_cmdline_opts = [
     ('ignore-source-changes', None,
      'Ignore all changes on source when building source package (add -i.* '
      'option to dpkg-source)'),
+    ('compress-xz', None,
+     'Use xzip (add -Zxz option to dpkg-buildpackage)'),
     ]
 
 # old entries from stdeb.cfg:
@@ -213,6 +215,7 @@ stdeb_cmd_bool_opts = [
     'with-dh-systemd',
     'sign-results',
     'ignore-source-changes',
+    'compress-xz',
     ]
 
 
@@ -1337,6 +1340,7 @@ def build_dsc(debinfo,
               debian_dir_only=False,
               sign_dsc=False,
               ignore_source_changes=False,
+              compress_xz=False,
               ):
     """make debian source package"""
     #    A. Find new dirname and delete any pre-existing contents
@@ -1565,6 +1569,9 @@ def build_dsc(debinfo,
 
     if ignore_source_changes:
         args.append('-i.*')
+
+    if compress_xz:
+        args.append('-Zxz')
 
     dpkg_buildpackage(*args, cwd=fullpath_repackaged_dirname)
 


### PR DESCRIPTION
- add compress xz (compress-xz)
  - In the latest Ubuntu, dpkg compresses to zst.
  - However, the lower Ubuntu does not support the compression format, resulting in an error.
  - To solve this problem, a parameter for compression to xz was added.