### PR TITLE
[Release] 0.11.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,11 +49,21 @@ interpreter (and only the Python3 package installs scripts)::
 News
 ----
 
+ * 2023-10-18: **Version 0.11.5**.
+
+  * Bugfixes:
+
+    * add compress-xz parameter
+
+  * Improvements:
+
+    * add use-exist-debian parameter
+
  * 2023-10-07: **Version 0.11.4**.
 
   * Improvements:
 
-    * add compress xz parameter
+    * add compress-xz parameter
 
  * 2023-09-08: **Version 0.11.2**.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name='stdeb',
     # Keep version in sync with stdeb/__init__.py and install section
     # of README.rst.
-    version='0.11.4',
+    version='0.11.5',
     author='DdangJin',
     author_email='hdj997@gmail.com',
     description='Python to Debian source package conversion utility',
@@ -17,7 +17,7 @@ setup(
     license='MIT',
     url='https://github.com/DdangJin/stdeb',
     packages=['stdeb', 'stdeb.command'],
-    python_requires='>=2.7,<3.12',
+    python_requires='>=2.7',
     scripts=[
         'scripts/py2dsc',
         'scripts/py2dsc-deb',

--- a/stdeb/__init__.py
+++ b/stdeb/__init__.py
@@ -1,5 +1,5 @@
 import logging
-__version__ = '0.11.4'  # keep in sync with ../setup.py
+__version__ = '0.11.5'  # keep in sync with ../setup.py
 
 log = logging.getLogger('stdeb')
 log.setLevel(logging.INFO)

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -37,6 +37,7 @@ class common_debian_package_command(Command):
         self.sign_results = False
         self.ignore_source_changes = False
         self.compress_xz = False
+        self.use_exist_debian = False
         self.compat = DH_DEFAULT_VERS
 
         # deprecated options
@@ -175,7 +176,11 @@ class common_debian_package_command(Command):
                              'you should move it alongside setup.py.' % entry)
                     cfg_files.append(config_fname)
 
-        upstream_version = self.distribution.get_version()
+        if self.use_exist_debian:
+            from pbr import version
+            upstream_version = version.VersionInfo(module_name).semantic_version().debian_string()
+        else:
+            upstream_version = self.distribution.get_version()
         bad_chars = ':_'
         for bad_char in bad_chars:
             if bad_char in upstream_version:

--- a/stdeb/command/sdist_dsc.py
+++ b/stdeb/command/sdist_dsc.py
@@ -143,6 +143,7 @@ class sdist_dsc(common_debian_package_command):
                   sign_dsc=self.sign_results,
                   ignore_source_changes=self.ignore_source_changes,
                   compress_xz=self.compress_xz,
+                  use_exist_debian=self.use_exist_debian,
                   )
 
         for rmdir in cleanup_dirs:


### PR DESCRIPTION
- Bugfixes
  - Fixed an issue where `compress-xz` is not functioning normally
- Improvements
  - add `use-exist-debian` parameter
    - Use exist debian directory, not create debian directory.
    - This uses the pbr version of upstream
       and creates new debian/changelog to match the upstream version
       without using the existing debian/changelog.
       (An error occurs if there is no debian directory.)